### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ $ python3 -m pip install django-traits
 
 ```python
 class Rich(Trait["Person"]):
+    q = models.Q(income__gt=1000)
+
     def check_instance(self, instance: Person) -> bool:
         return instance.income > 1000
-
-    def as_q(self) -> models.Q:
-        return models.Q(income__gt=1000)
 
 
 class Person(models.Model):
@@ -29,7 +28,7 @@ class Person(models.Model):
     income = models.PositiveIntegerField()
 
 
-# Filter for rich people, this uses the ORM predicate as defined in as_q().
+# Filter for rich people, this uses the ORM predicate as defined in q.
 rich_people = Person.is_rich.all()
 
 # Check if a person is rich, this uses the in-Python predicate as defined in check_instance().
@@ -40,8 +39,8 @@ else:
     print("This person is not rich")
 ```
 
-The automated test factory makes it simple to write tests that guarantees
-that the in-Python predicate stays in sync with its ORM counterpart.
+The automated test factory makes it simple to write tests that guarantees that the
+in-Python predicate stays in sync with its ORM counterpart.
 
 ```python
 class TestPerson:
@@ -54,7 +53,7 @@ class TestPerson:
     )
 ```
 
-The above example will generate tests that exercises the in-Python predicate on instances of `Person`,
-as well as tests that tries to filter using the ORM predicate. That means that if the implementations
-were to drift apart, for instance if the limit was increased to `2000` in `check_instance()` but not
-in `as_q()`, the tests would fail.
+The above example will generate tests that exercises the in-Python predicate on
+instances of `Person`, as well as tests that tries to filter using the ORM predicate.
+That means that if the implementations were to drift apart, for instance if the limit
+was increased to `2000` in `check_instance()` but not in `q`, the tests would fail.

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ test =
     pytest
     pytest-django
     pytest-mypy-plugins
+    django-stubs
     coverage
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ traits = py.typed
 test =
     pytest
     pytest-django
+    pytest-mypy-plugins
     coverage
 
 [flake8]

--- a/src/traits/base.py
+++ b/src/traits/base.py
@@ -1,54 +1,46 @@
 from __future__ import annotations
 
 import abc
-from functools import cached_property
 from typing import Generic
 from typing import TypeVar
-from typing import final
 from typing import overload
 
 from django.db import models
 
 M = TypeVar("M", bound=models.Model)
+S = TypeVar("S", bound="Trait")
 
 
 class Trait(Generic[M], abc.ABC):
     def __init__(self) -> None:
         self._model: type[M] | None = None
 
+    @property
     @abc.abstractmethod
-    def as_q(self) -> models.Q:
+    def q(self) -> models.Q:
         ...
 
     @abc.abstractmethod
     def check_instance(self, instance: M) -> bool:
         ...
 
-    @final
-    @cached_property
-    def q(self) -> models.Q:
-        return self.as_q()
-
     def all(self) -> models.QuerySet[M]:
-        # TODO: Good error message.
-        assert self._model is not None
-        return self._model.objects.filter(self.as_q())
-
-    @overload
-    def __get__(self: Trait[M], instance: M, owner: type[M]) -> bool:
-        ...
-
-    @overload
-    def __get__(self: Trait[M], instance: None, owner: type[M]) -> Trait[M]:
-        ...
-
-    def __get__(self: Trait[M], instance: M | None, owner: type[M]) -> bool | Trait[M]:
-        # TODO: Use inspect.isabstract() to make sure abstract traits can't be bound.
         if self._model is None:
-            self._model = owner
-        else:
-            assert self._model is owner
-        if instance is None:
-            return self
-        else:
-            return self.check_instance(instance)
+            raise TypeError(f"Can't call .all() on unbound {type(self).__qualname__}")
+        return self._model.objects.filter(self.q)
+
+    def __set_name__(self, owner: type[M], name: str) -> None:
+        if self._model is not None:
+            raise TypeError("Can't reuse bound trait")
+        self._model = owner
+
+    @overload
+    def __get__(self: S, instance: None, owner: type[M]) -> S:
+        ...
+
+    @overload
+    def __get__(self, instance: models.Model, owner: type[M]) -> bool:
+        ...
+
+    def __get__(self: S, instance: models.Model | None, owner: type[M]) -> bool | S:
+        return self if instance is None else self.check_instance(instance)

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -6,11 +6,10 @@ from traits import Trait
 
 
 class Rich(Trait["Person"]):
+    q = models.Q(income__gt=1000)
+
     def check_instance(self, instance: Person) -> bool:
         return instance.income > 1000
-
-    def as_q(self) -> models.Q:
-        return models.Q(income__gt=1000)
 
 
 class Person(models.Model):

--- a/tests/test_trait.py
+++ b/tests/test_trait.py
@@ -1,4 +1,7 @@
 import pytest
+from django.db import models
+
+from traits import Trait
 
 from .app.models import Person
 
@@ -11,3 +14,48 @@ def test_basics() -> None:
     assert list(query_rich) == [rich]
     query_poor = Person.objects.filter(~Person.is_rich.q)
     assert list(query_poor) == [poor]
+
+
+def test_instantiating_abstract_traits_raises_type_error() -> None:
+    class MissingCheckInstance(Trait):
+        q = models.Q()
+
+    class MissingQ(Trait):
+        def check_instance(self, instance: models.Model) -> bool:
+            return True
+
+    raises = pytest.raises(TypeError, match=r"^Can't instantiate")
+
+    with raises:
+        MissingCheckInstance()  # type: ignore[abstract]
+    with raises:
+        MissingQ()  # type: ignore[abstract]
+
+
+class DummyTrait(Trait):
+    q = models.Q()
+
+    def check_instance(self, instance: models.Model) -> bool:
+        return True
+
+
+def test_reusing_bound_trait_raises_type_error() -> None:
+    class ConflictingOwner:
+        trait = DummyTrait()
+
+    with pytest.raises(RuntimeError) as exc_info:
+
+        class _:
+            trait = ConflictingOwner.trait
+
+    assert type(exc_info.value.__cause__) is TypeError
+    assert str(exc_info.value.__cause__) == "Can't reuse bound trait"
+
+
+def test_filtering_unbound_trait_raises_type_error() -> None:
+    unbound = DummyTrait()
+    with pytest.raises(
+        TypeError,
+        match=fr"Can't call \.all\(\) on unbound {DummyTrait.__qualname__}",
+    ):
+        unbound.all()

--- a/tests/test_trait.yaml
+++ b/tests/test_trait.yaml
@@ -1,0 +1,17 @@
+- case: test_reveals_correct_bound_types
+  main: |
+    from traits import Trait
+    from django.db import models
+    class Bar(Trait[models.Model]):
+        q = models.Q()
+        def check_instance(self, instance: models.Model) -> bool:
+            return True
+    class Foo(models.Model):
+        t = Bar()
+        class Meta:
+            app_label = "app"
+    reveal_type(Foo().t) # N: Revealed type is "builtins.bool"
+    reveal_type(Foo.t) # N: Revealed type is "main.Bar"
+  mypy_config: |
+    [mypy-django.*]
+    ignore_errors = True


### PR DESCRIPTION
- Fixes overload of `Trait.__get__` and add type tests that locks this in.
- Drops `Trait.as_q()` in favor of a simpler `Trait.q` abstract property.
- Improves error messages for misconfiguration and adds tests.